### PR TITLE
docs: Add Chinese instructions for running the program

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,64 @@
 - 分页显示
 - SEO 友好
 
+## 如何运行此程序
+
+要成功运行此博客系统，您需要遵循以下步骤：
+
+**1. 安装 Python:**
+   - 确保您的计算机上安装了 Python (版本 3.x 或更高版本)。
+   - 您可以从 [Python 官网](https://www.python.org/downloads/) 下载并安装。
+   - (可选) 对于中国大陆用户，为了加快后续步骤中依赖包的下载速度，建议配置 pip 使用国内镜像源。打开命令行并运行：
+     ```bash
+     pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+     ```
+
+**2. 克隆代码库:**
+   - 如果您还没有项目的代码，请先克隆代码库：
+     ```bash
+     git clone https://github.com/dazhongqi789/Simpleblog.git
+     cd Simpleblog
+     ```
+
+**3. 创建并激活虚拟环境:**
+   - 在项目根目录下，创建一个 Python 虚拟环境。这有助于隔离项目依赖。
+     ```bash
+     python -m venv venv
+     ```
+   - 激活虚拟环境：
+     - Windows: `venv\Scriptsctivate`
+     - macOS/Linux: `source venv/bin/activate`
+   - 激活成功后，命令行提示符前通常会显示 `(venv)`。
+
+**4. 安装项目依赖:**
+   - 确保虚拟环境已激活，然后使用 `requirements.txt` 文件安装所有必需的 Python 包：
+     ```bash
+     pip install -r requirements.txt
+     ```
+
+**5. 配置环境变量:**
+   - 项目使用 `.env` 文件来管理敏感配置（例如操作密码）。
+   - 复制项目中的 `.env.example` 文件并将其重命名为 `.env`。
+     ```bash
+     # 在 Windows 命令提示符中
+     copy .env.example .env
+     # 或在 PowerShell 或 macOS/Linux 终端中
+     # cp .env.example .env
+     ```
+   - 打开 `.env` 文件，并根据您的需求修改其中的配置项，特别是 `OPERATION_PASSWORD`，它用于文章的上传和删除。
+
+**6. 初始化数据库并运行程序:**
+   - 运行主应用程序脚本 `app.py`。这将初始化数据库（如果尚未创建）并启动开发服务器：
+     ```bash
+     python app.py
+     ```
+
+**7. 访问应用:**
+   - 程序默认在本地的 80 端口运行。
+   - 打开您的网页浏览器，访问 `http://127.0.0.1` 或 `http://localhost` (如果80端口被占用，请根据 `app.py` 中的配置或命令行输出确认实际端口和IP地址)。
+
+---
+
 ## 安装步骤
 
 1. 克隆仓库


### PR DESCRIPTION
I added a new section "如何运行此程序" to README.md.

This section provides comprehensive, step-by-step instructions in Chinese on how to set up the environment and run the application. It covers:
- Python installation
- Cloning the repository
- Creating and activating a virtual environment
- Installing dependencies via requirements.txt
- Configuring environment variables using .env
- Running the application
- Accessing the application in a browser

This addresses your query about what is needed to run the program.